### PR TITLE
Remove unneeded checkbox opacity (fixes #32)

### DIFF
--- a/vaadin-components-gwt/src/main/java/com/vaadin/components/grid/selection/IndexBasedSelectionModelMultiAbstract.java
+++ b/vaadin-components-gwt/src/main/java/com/vaadin/components/grid/selection/IndexBasedSelectionModelMultiAbstract.java
@@ -28,6 +28,7 @@ public abstract class IndexBasedSelectionModelMultiAbstract extends
                         .createCheckInputElement();
                 LabelElement label = Document.get().createLabelElement();
                 checkbox.setId(DOM.createUniqueId());
+                checkbox.setTabIndex(-1);
                 label.setHtmlFor(checkbox.getId());
                 cell.getElement().removeAllChildren();
                 cell.getElement().appendChild(checkbox);

--- a/vaadin-components-gwt/src/main/webapp/vaadin-grid/vaadin-grid.html
+++ b/vaadin-components-gwt/src/main/webapp/vaadin-grid/vaadin-grid.html
@@ -310,10 +310,6 @@
     outline: none;
   }
 
-  input[type="checkbox"]:focus + label {
-    border-color: rgba(0,0,0,0.6);
-  }
-
   input[type="checkbox"] + label:after {
     content: url("tick.svg");
     position: absolute;


### PR DESCRIPTION
Default color (opacity 0.3) is already specified. 0.6 opacity is different and never seen in the grid because it will be always overriden by the blue color. So practically it's not needed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/components/36)
<!-- Reviewable:end -->
