### PR TITLE
Ignore navigation event bubbling from focused cell content (Fixes #31)

### DIFF
--- a/vaadin-components-gwt/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/vaadin-components-gwt/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -2059,11 +2059,21 @@ public class Grid<T> extends ResizeComposite implements
          * Handle events that can move the cell focus.
          */
         public void handleNavigationEvent(Event event, CellReference<T> cell) {
+            Element focusedElement = WidgetUtil.getFocusedElement();
+
+            // Ignore most events bubbling from a focused element in the cell
+            boolean focusInsideCell = focusedElement != null
+                    && cell.getElement().isOrHasChild(focusedElement);
+
             if (event.getType().equals(BrowserEvents.CLICK)) {
                 setCellFocus(cell);
-                // Grid should have focus when clicked.
-                getElement().focus();
-            } else if (event.getType().equals(BrowserEvents.KEYDOWN)) {
+                // Grid should have focus when cell is clicked, unless focus is
+                // in the cell contents
+                if (!focusInsideCell) {
+                    getElement().focus();
+                }
+            } else if (event.getType().equals(BrowserEvents.KEYDOWN)
+                    && !focusInsideCell) {
                 int newRow = rowWithFocus;
                 RowContainer newContainer = containerWithFocus;
                 int newColumn = cellFocusRange.getStart();


### PR DESCRIPTION
The fix requires modifications in private class `CellFocusHandler` in `Grid.java`.
Fork #47 was created first then this branch contains the fix.
This fix is a manual merge of Vaadin Review https://dev.vaadin.com/review/#/c/11399/1 and Grid.java 7.5.0.beta1 https://github.com/vaadin/vaadin/blob/7.5.0.beta1/client/src/com/vaadin/client/widgets/Grid.java (or #47)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/components/50)
<!-- Reviewable:end -->
