### PR TITLE
New function datasources no longer cause datasource change internally

### DIFF
--- a/vaadin-components-gwt/src/main/java/com/vaadin/components/grid/GridComponent.java
+++ b/vaadin-components-gwt/src/main/java/com/vaadin/components/grid/GridComponent.java
@@ -268,7 +268,11 @@ public class GridComponent implements SelectionHandler<Object>,
 
     public void setDataSource(JavaScriptObject data) {
         if (JsUtils.isFunction(data)) {
-            grid.setDataSource(new GridJsFuncDataSource(data, this));
+            if (getDataSource() instanceof GridJsFuncDataSource) {
+                ((GridJsFuncDataSource) getDataSource()).setJSFunction(data);
+            } else {
+                grid.setDataSource(new GridJsFuncDataSource(data, this));
+            }
             updateHeight();
         } else {
             throw new RuntimeException("Unknown data source type: " + data

--- a/vaadin-components-gwt/src/main/java/com/vaadin/components/grid/data/GridJsFuncDataSource.java
+++ b/vaadin-components-gwt/src/main/java/com/vaadin/components/grid/data/GridJsFuncDataSource.java
@@ -15,7 +15,7 @@ import com.vaadin.components.grid.config.JSDataRequest;
  */
 public class GridJsFuncDataSource extends GridDataSource {
 
-    private final JavaScriptObject jsFunction;
+    private JavaScriptObject jsFunction;
     private boolean initialRowSetReceived;
 
     public GridJsFuncDataSource(JavaScriptObject jso, GridComponent grid) {
@@ -26,6 +26,12 @@ public class GridJsFuncDataSource extends GridDataSource {
         // and then attach the data-source to the grid, otherwise the grid will
         // never call the requestRows method when size is zero.
         doRequest(0, 0, null);
+    }
+
+    public void setJSFunction(JavaScriptObject jso) {
+        jsFunction = jso;
+        clearCache(null);
+        gridComponent.getSelectionModel().reset();
     }
 
     @Override


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/components/84)
<!-- Reviewable:end -->
