### PR TITLE
Fixes row details problems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - Added data.getItem api for fetching data items by row index (#45)
 - Combined multi selection models into one model
 - Moved row focus indicator line from the bottom to the left side of a row
+- Added row details feature
 - Issues fixed:
   - Grid doesn't work when using selection-mode multi, frozen columns and sortable columns. (#7)
   - Grid height is recalculated incorrectly when sorting a grid with a fixed height. (#8)

--- a/vaadin-components-gwt/src/main/java/com/vaadin/client/widgets/Grid.java
+++ b/vaadin-components-gwt/src/main/java/com/vaadin/client/widgets/Grid.java
@@ -169,6 +169,7 @@ import com.vaadin.shared.util.SharedUtil;
 // Applied changes:
 // https://dev.vaadin.com/review/#/c/11846/
 // https://dev.vaadin.com/review/#/c/11876/
+// https://dev.vaadin.com/review/#/c/11919/
 /**
  * A data grid view that supports columns and lazy loading of data rows from a
  * data source.
@@ -2409,7 +2410,7 @@ public class Grid<T> extends ResizeComposite implements
              * TODO: Currently the select all check box is shown when multi
              * selection is in use. This might result in malfunctions if no
              * SelectAllHandlers are present.
-             *
+             * 
              * Later on this could be fixed so that it check such handlers
              * exist.
              */
@@ -2781,7 +2782,7 @@ public class Grid<T> extends ResizeComposite implements
             /*
              * Set all fixed widths and also calculate the size-to-fit widths
              * for the autocalculated columns.
-             *
+             * 
              * This way we know with how many pixels we have left to expand the
              * rest.
              */
@@ -3073,7 +3074,7 @@ public class Grid<T> extends ResizeComposite implements
                 /*
                  * Once we have the content properly inside the DOM, we should
                  * re-measure it to make sure that it's the correct height.
-                 *
+                 * 
                  * This is rather tricky, since the row (tr) will get the
                  * height, but the spacer cell (td) has the borders, which
                  * should go on top of the previous row and next row.
@@ -4795,7 +4796,7 @@ public class Grid<T> extends ResizeComposite implements
             } else {
                 /*
                  * NOOP
-                 *
+                 * 
                  * Since setGrid() will call reapplyWidths as the colum is
                  * attached to a grid, it will call setWidth, which, in turn,
                  * will call this method again. Therefore, it's guaranteed that
@@ -6372,7 +6373,7 @@ public class Grid<T> extends ResizeComposite implements
          * widget dimensions (height/width) on each state change event. The
          * original design was to have setHeight an setHeightByRow be equals,
          * and whichever was called the latest was considered in effect.
-         *
+         * 
          * But, because of Vaadin always calling setHeight on the widget, this
          * approach doesn't work.
          */
@@ -7806,7 +7807,7 @@ public class Grid<T> extends ResizeComposite implements
          * corresponding Widget will call removeFromParent() on itself. GWT will
          * check there that its parent (i.e. Grid) implements HasWidgets, and
          * will call this remove(Widget) method.
-         *
+         * 
          * tl;dr: all this song and dance to make sure GWT's sanity checks
          * aren't triggered, even though they effectively do nothing interesting
          * from Grid's perspective.
@@ -7879,6 +7880,10 @@ public class Grid<T> extends ResizeComposite implements
                     "Details generator may not be null");
         }
 
+        for (Integer rowIndex : visibleDetails) {
+            setDetailsVisible(rowIndex, false);
+        }
+
         this.detailsGenerator = detailsGenerator;
 
         // this will refresh all visible spacers
@@ -7915,17 +7920,17 @@ public class Grid<T> extends ResizeComposite implements
         /*
          * We want to prevent opening a details row twice, so any subsequent
          * openings (or closings) of details is a NOOP.
-         *
+         * 
          * When a details row is opened, it is given an arbitrary height
          * (because Escalator requires a height upon opening). Only when it's
          * opened, Escalator will ask the generator to generate a widget, which
          * we then can measure. When measured, we correct the initial height by
          * the original height.
-         *
+         * 
          * Without this check, we would override the measured height, and revert
          * back to the initial, arbitrary, height which would most probably be
          * wrong.
-         *
+         * 
          * see GridSpacerUpdater.init for implementation details.
          */
 

--- a/vaadin-components-gwt/src/main/java/com/vaadin/components/grid/GridComponent.java
+++ b/vaadin-components-gwt/src/main/java/com/vaadin/components/grid/GridComponent.java
@@ -32,6 +32,7 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.SimplePanel;
+import com.vaadin.client.widget.grid.DetailsGenerator;
 import com.vaadin.client.widget.grid.events.SelectAllEvent;
 import com.vaadin.client.widget.grid.events.SelectAllHandler;
 import com.vaadin.client.widget.grid.selection.SelectionEvent;
@@ -586,7 +587,7 @@ public class GridComponent implements SelectionHandler<Object>,
     }
 
     public void setRowDetailsGenerator(JavaScriptObject generator) {
-        grid.setDetailsGenerator(JS.isUndefinedOrNull(generator) ? null
+        grid.setDetailsGenerator(JS.isUndefinedOrNull(generator) ? DetailsGenerator.NULL
                 : rowIndex -> {
                     Object details = JS.exec(generator, rowIndex);
                     return JS.isUndefinedOrNull(details) ? null
@@ -600,11 +601,12 @@ public class GridComponent implements SelectionHandler<Object>,
         return rowDetailsGenerator;
     }
 
-    public void setRowDetailsVisible(int rowIndex, boolean visible) {
+    public void setRowDetailsVisible(int rowIndex, Object visible) {
         Integer validatedRowIndex = JSValidate.Integer
                 .val(rowIndex, null, null);
         Boolean validatedVisible = JSValidate.Boolean.val(visible, true, true);
-        if (validatedRowIndex != null) {
+        if (!DetailsGenerator.NULL.equals(grid.getDetailsGenerator())
+                && validatedRowIndex != null) {
             grid.setDetailsVisible(validatedRowIndex, validatedVisible);
         }
     }

--- a/vaadin-components-gwt/src/main/webapp/vaadin-grid/test/grid-properties.html
+++ b/vaadin-components-gwt/src/main/webapp/vaadin-grid/test/grid-properties.html
@@ -16,101 +16,125 @@
 <div id="gridwrapper"></div>
 
 <script>
-  describe.feature('using properties', function() {
-    it('rowClassGenerator', function() {
-      var gridEquals = true;
-      var elementEquals = true;
-      assert.notOk(grid.rowClassGenerator);
-      var rowClassGenerator = function(row) {
-        gridEquals = gridEquals && row.grid == grid;
-        elementEquals = elementEquals && row.element == qaLocal(".v-grid-body .v-grid-row")[row.index];
-        return row.index + "_" + row.data[0];
-      };
+describe.feature('using properties', function() {
+  it('rowClassGenerator', function() {
+    var gridEquals = true;
+    var elementEquals = true;
+    assert.notOk(grid.rowClassGenerator);
+    var rowClassGenerator = function(row) {
+      gridEquals = gridEquals && row.grid == grid;
+      elementEquals = elementEquals && row.element == qaLocal(".v-grid-body .v-grid-row")[row.index];
+      return row.index + "_" + row.data[0];
+    };
 
-      grid.rowClassGenerator = rowClassGenerator;
+    grid.rowClassGenerator = rowClassGenerator;
 
-      assert.isTrue(elementEquals && gridEquals);
-      assert.equal(grid.rowClassGenerator, rowClassGenerator);
-      return grid.then(function(){
-        assert.isTrue(qLocal(".v-grid-body .v-grid-row").classList.contains("0_Grid"));
-      });
-    });
-
-    it('cellClassGenerator', function() {
-      var elementEquals = true;
-
-      grid.columns[0].name = "name";
-      grid.columns[1].name = "value";
-      assert.notOk(grid.cellClassGenerator);
-      var cellClassGenerator = function(cell) {
-        var columnIndex = cell.columnName == "name" ? 0 : 1;
-        var cellElement = qaLocal(".v-grid-body .v-grid-row")[cell.row.index].querySelectorAll(".v-grid-cell")[columnIndex];
-        elementEquals = elementEquals && cell.element == cellElement;
-        return cell.columnName;
-      };
-
-      grid.cellClassGenerator = cellClassGenerator;
-
-      assert.isTrue(elementEquals);
-      assert.equal(grid.cellClassGenerator, cellClassGenerator);
-      return grid.then(function(){
-        assert.isTrue(qLocal(".v-grid-body .v-grid-row .v-grid-cell").classList.contains("name"));
-      });
-    });
-
-    it('RowDetailsGenerator should be correctly set', function() {
-      assert.notOk(grid.rowDetailsGenerator);
-
-      var rowDetailsGenerator = function(rowIndex) {
-        var detail = document.createElement('div');
-        detail.className = 'detail-content-' + rowIndex;
-        detail.textContent = 'Row detail content for row ' + rowIndex;
-        return detail;
-      };
-      grid.rowDetailsGenerator = rowDetailsGenerator;
-
-      assert.equal(grid.rowDetailsGenerator, rowDetailsGenerator);
-    });
-
-    it('RowDetailsGenerator should be correctly shown', function() {
-      return grid.then(function() {
-        grid.setRowDetailsVisible(0, true);
-        assert.equal(qLocal(".detail-content-0").textContent, "Row detail content for row 0");
-      });
-    });
-
-    it('RowDetailsGenerator should be correctly hidden', function() {
-      return grid.then(function() {
-        grid.setRowDetailsVisible(0, true);
-        grid.setRowDetailsVisible(0, false);
-        assert.notOk(qLocal(".detail-content-0"));
-      });
-    });
-
-    it('should be enabled by default', function() {
-      expect(grid.disabled).to.be.false;
-    });
-
-    it('should disable', function() {
-      grid.disabled = true;
-      expect(grid.disabled).to.be.true;
-    });
-
-    it('should reflect disabled to attribute', function() {
-      grid.disabled = true;
-      expect(grid.hasAttribute("disabled")).to.be.true;
-      grid.disabled = false;
-      expect(grid.hasAttribute("disabled")).to.be.false;
-    });
-
-    it('should apply disabled attribute', function() {
-      grid.setAttribute("disabled", true);
-      expect(grid.disabled).to.be.true;
-      grid.removeAttribute("disabled");
-      expect(grid.disabled).to.be.false;
+    assert.isTrue(elementEquals && gridEquals);
+    assert.equal(grid.rowClassGenerator, rowClassGenerator);
+    return grid.then(function(){
+      assert.isTrue(qLocal(".v-grid-body .v-grid-row").classList.contains("0_Grid"));
     });
   });
 
+  it('cellClassGenerator', function() {
+    var elementEquals = true;
+
+    grid.columns[0].name = "name";
+    grid.columns[1].name = "value";
+    assert.notOk(grid.cellClassGenerator);
+    var cellClassGenerator = function(cell) {
+      var columnIndex = cell.columnName == "name" ? 0 : 1;
+      var cellElement = qaLocal(".v-grid-body .v-grid-row")[cell.row.index].querySelectorAll(".v-grid-cell")[columnIndex];
+      elementEquals = elementEquals && cell.element == cellElement;
+      return cell.columnName;
+    };
+
+    grid.cellClassGenerator = cellClassGenerator;
+
+    assert.isTrue(elementEquals);
+    assert.equal(grid.cellClassGenerator, cellClassGenerator);
+    return grid.then(function(){
+      assert.isTrue(qLocal(".v-grid-body .v-grid-row .v-grid-cell").classList.contains("name"));
+    });
+  });
+
+  it('Row details should not be shown if generator is not set', function() {
+    return grid.then(function() {
+      grid.setRowDetailsVisible(0, true);
+      assert.notOk(qLocal(".v-grid-spacer"));
+    });
+  });
+
+  it('RowDetailsGenerator should be correctly set', function() {
+    assert.notOk(grid.rowDetailsGenerator);
+
+    var rowDetailsGenerator = function(rowIndex) {
+      var detail = document.createElement('div');
+      detail.className = 'detail-content-' + rowIndex;
+      detail.textContent = 'Row detail content for row ' + rowIndex;
+      return detail;
+    };
+    grid.rowDetailsGenerator = rowDetailsGenerator;
+
+    assert.equal(grid.rowDetailsGenerator, rowDetailsGenerator);
+  });
+
+  it('Row details should be correctly shown', function() {
+    return grid.then(function() {
+      grid.setRowDetailsVisible(0, true);
+      assert.equal(qLocal(".detail-content-0").textContent, "Row detail content for row 0");
+      grid.setRowDetailsVisible(0, false);
+    });
+  });
+
+  it('Row details should be correctly shown with no boolean param', function() {
+    return grid.then(function() {
+      grid.setRowDetailsVisible(0);
+      assert.equal(qLocal(".detail-content-0").textContent, "Row detail content for row 0");
+      grid.setRowDetailsVisible(0, false);
+    });
+  });
+
+  it('Row details should be correctly hidden', function() {
+    return grid.then(function() {
+      grid.setRowDetailsVisible(0, true);
+      grid.setRowDetailsVisible(0, false);
+      assert.notOk(qLocal(".detail-content-0"));
+    });
+  });
+
+  it('Row details should be hidden if generator is reset', function() {
+    return grid.then(function() {
+      grid.setRowDetailsVisible(0, true);
+      grid.rowDetailsGenerator = undefined;
+      assert.notOk(qLocal(".v-grid-spacer"));
+      grid.setRowDetailsVisible(0, false);
+    });
+  });
+
+  it('should be enabled by default', function() {
+    expect(grid.disabled).to.be.false;
+  });
+
+  it('should disable', function() {
+    grid.disabled = true;
+    expect(grid.disabled).to.be.true;
+  });
+
+  it('should reflect disabled to attribute', function() {
+    grid.disabled = true;
+    expect(grid.hasAttribute("disabled")).to.be.true;
+    grid.disabled = false;
+    expect(grid.hasAttribute("disabled")).to.be.false;
+  });
+
+  it('should apply disabled attribute', function() {
+    grid.setAttribute("disabled", true);
+    expect(grid.disabled).to.be.true;
+    grid.removeAttribute("disabled");
+    expect(grid.disabled).to.be.false;
+  });
+});
 </script>
 
 </body>


### PR DESCRIPTION
 - Use the proper DetailsGenerator.NULL when undef is given from JS
 - Close all visible details when the generator is changed
 - Fixed setRowDetailsVisible(idx) to actually show the details

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/components/112)
<!-- Reviewable:end -->
