### PR TITLE
Fix the column hiding dropdown icon size in IE11

### DIFF
--- a/vaadin-components-gwt/src/main/webapp/vaadin-grid/vaadin-grid.html
+++ b/vaadin-components-gwt/src/main/webapp/vaadin-grid/vaadin-grid.html
@@ -556,6 +556,7 @@ More examples available at http://vaadin.github.io/components-examples/vaadin-gr
     position:absolute;
     top: 14px;
     left: 16px;
+    width: 24px;
   }
 
   .vaadin-grid-sidebar-content {


### PR DESCRIPTION
#130

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/components/138)
<!-- Reviewable:end -->
